### PR TITLE
"Inline-ify" functions

### DIFF
--- a/source/GameState.hx
+++ b/source/GameState.hx
@@ -22,7 +22,7 @@ class GameState extends FlxState
 		super.update(elapsed);
 	}
 
-	public function transIn(color:FlxColor, desiredState:FlxState)
+	public inline function transIn(color:FlxColor, desiredState:FlxState)
 	{
 		this.desiredState = desiredState;
 		transitionSprite = new FlxSprite(-FlxG.width, 0).makeGraphic(FlxG.width, FlxG.height, color, false);
@@ -30,14 +30,14 @@ class GameState extends FlxState
 		FlxTween.tween(transitionSprite, {x: 0}, 0.5, {ease: FlxEase.quintInOut, onComplete: switchThing});
 	}
 
-	public function transOut(color:FlxColor)
+	public inline function transOut(color:FlxColor)
 	{
 		transitionSprite = new FlxSprite(0, 0).makeGraphic(FlxG.width, FlxG.height, color, false);
 		add(transitionSprite);
 		FlxTween.tween(transitionSprite, {x: FlxG.width}, 0.5, {ease: FlxEase.quintInOut});
 	}
 
-	function switchThing(tween:FlxTween)
+	function inline switchThing(tween:FlxTween)
 	{
 		remove(transitionSprite);
 		FlxG.switchState(desiredState);


### PR DESCRIPTION
The code in the functions are very simple, so making them into plain code (make it 'not' be a function) can improve execution time by the target code not having to read and then call a function.